### PR TITLE
Implement Afíliate feature with push

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,8 +6,9 @@ import { AuthProvider, useAuth } from './src/context/AuthContext';
 import RootNavigator from './src/navigation/RootNavigator';
 import { View, Text, Alert, Vibration } from 'react-native';
 import * as Notifications from 'expo-notifications';
-import { getFirestore, collection, doc, setDoc } from '@react-native-firebase/firestore';
+import { getFirestore, doc, setDoc, serverTimestamp } from '@react-native-firebase/firestore';
 import { getApp } from '@react-native-firebase/app';
+import { requestPushPermission } from './src/services/notifications';
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -20,23 +21,26 @@ Notifications.setNotificationHandler({
 function MainApp() {
   const notificationListener = useRef<any>();
   const responseListener = useRef<any>();
-  const { user } = useAuth();
+  const { user, isAdmin } = useAuth();
 
   useEffect(() => {
-    if (!user) return;
+    if (!user || !isAdmin) return;
 
     const setupPushNotifications = async () => {
-      const { status } = await Notifications.requestPermissionsAsync();
-      if (status !== 'granted') {
+      let token: string;
+      try {
+        token = await requestPushPermission();
+      } catch (err) {
         Alert.alert('Permiso denegado', 'No se concedieron permisos para notificaciones push');
         return;
       }
-      const token = (await Notifications.getExpoPushTokenAsync()).data;
       try {
         const db = getFirestore(getApp());
-        const usersCollection = collection(db, 'users');
-        const userDocRef = doc(usersCollection, user.uid);
-        await setDoc(userDocRef, { expoPushToken: token }, { merge: true });
+        await setDoc(
+          doc(db, 'adminPushTokens', user.uid),
+          { expoPushToken: token, updatedAt: serverTimestamp() },
+          { merge: true }
+        );
         console.log('Expo Push Token guardado en Firestore:', token);
       } catch (err) {
         console.error('Error guardando token en Firestore:', err);
@@ -44,7 +48,7 @@ function MainApp() {
     };
 
     setupPushNotifications();
-  }, [user]);
+  }, [user, isAdmin]);
 
   useEffect(() => {
     notificationListener.current = Notifications.addNotificationReceivedListener(notification => {

--- a/README.md
+++ b/README.md
@@ -140,3 +140,14 @@ BancaApp/
 ## 📄 Licencia
 
 Este proyecto está bajo la licencia **MIT**.
+## 📲 Notificaciones push para administradores
+
+1. En Firestore, crea o edita el documento `users/{uid}` del administrador y establece `isAdmin: true`.
+2. Desde la pestaña **Admin** dentro de la app, pulsa **Registrar mis notificaciones** para guardar el token de Expo.
+3. Los usuarios pueden solicitar afiliación en la pestaña **Afíliate** y los administradores recibirán un aviso push.
+
+Para desplegar las reglas de seguridad ejecuta:
+
+```bash
+firebase deploy --only firestore:rules
+```

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,13 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /affiliateRequests/{docId} {
+      allow create: if request.auth != null;
+      allow read, update, delete: if get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true;
+    }
+    match /adminPushTokens/{uid} {
+      allow write: if request.auth != null && request.auth.uid == uid;
+      allow read: if get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true;
+    }
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@expo/config-plugins": "~9.0.0",
         "@expo/metro-runtime": "~4.0.1",
         "@expo/vector-icons": "~14.0.4",
+        "@hookform/resolvers": "^5.1.1",
         "@react-native-firebase/app": "^22.2.0",
         "@react-native-firebase/auth": "^22.2.0",
         "@react-native-firebase/firestore": "^22.2.0",
@@ -3896,6 +3897,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.1.1.tgz",
+      "integrity": "sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -5329,6 +5342,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "@expo/config-plugins": "~9.0.0",
     "@expo/metro-runtime": "~4.0.1",
+    "@expo/vector-icons": "~14.0.4",
+    "@hookform/resolvers": "^5.1.1",
     "@react-native-firebase/app": "^22.2.0",
     "@react-native-firebase/auth": "^22.2.0",
     "@react-native-firebase/firestore": "^22.2.0",
@@ -25,6 +27,7 @@
     "dotenv": "^16.5.0",
     "expo": "~52.0.46",
     "expo-asset": "~11.0.5",
+    "expo-build-properties": "~0.13.3",
     "expo-dev-client": "~5.0.20",
     "expo-font": "~13.0.4",
     "expo-linear-gradient": "~14.0.2",
@@ -42,9 +45,7 @@
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.5",
     "yup": "^1.6.1",
-    "zustand": "^5.0.3",
-    "expo-build-properties": "~0.13.3",
-    "@expo/vector-icons": "~14.0.4"
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -7,17 +7,18 @@ import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { Ionicons } from "@expo/vector-icons";
 
 import BenefitsListScreen from "../screens/benefits/BenefitsListScreen";
-
 import CredentialScreen from "../screens/credential/DigitalCredentialScreen";
-
 import NewsListScreen from "../screens/news/NewsListScreen";
-
 import ProfileScreen from "../screens/profile/ProfileScreen";
 import ContactScreen from "../screens/contact/ContactScreen";
+import AfiliateScreen from "../screens/AfiliateScreen";
+import AdminScreen from "../screens/AdminScreen";
+import { useAuth } from "../context/AuthContext";
 
 const Tab = createBottomTabNavigator();
 
 const TabNavigator = () => {
+  const { isAdmin } = useAuth();
   return (
     <Tab.Navigator
       screenOptions={({ route }) => ({
@@ -34,6 +35,8 @@ const TabNavigator = () => {
 
           if (route.name === "Profile") iconName = "person-outline";
           if (route.name === "Contact") iconName = "logo-whatsapp";
+          if (route.name === "Afiliate") iconName = "person-add-outline";
+          if (route.name === "Admin") iconName = "settings-outline";
 
           // Fix 1: Forzar cast del iconName si TS no lo reconoce:
 
@@ -68,6 +71,12 @@ const TabNavigator = () => {
       />
 
       <Tab.Screen
+        name="Afiliate"
+        component={AfiliateScreen}
+        options={{ title: "Afíliate" }}
+      />
+
+      <Tab.Screen
         name="Profile"
         component={ProfileScreen}
         options={{ title: "Perfil" }}
@@ -78,6 +87,14 @@ const TabNavigator = () => {
         component={ContactScreen}
         options={{ title: "Contacto" }}
       />
+
+      {isAdmin && (
+        <Tab.Screen
+          name="Admin"
+          component={AdminScreen}
+          options={{ title: "Admin" }}
+        />
+      )}
     </Tab.Navigator>
   );
 };

--- a/src/screens/AdminScreen.tsx
+++ b/src/screens/AdminScreen.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { View, Button, Alert } from 'react-native';
+import { getFirestore, doc, setDoc, serverTimestamp } from '@react-native-firebase/firestore';
+import { getApp } from '@react-native-firebase/app';
+import { useAuth } from '../context/AuthContext';
+import { requestPushPermission } from '../services/notifications';
+
+const AdminScreen: React.FC = () => {
+  const { user } = useAuth();
+  const [loading, setLoading] = useState(false);
+
+  const registerToken = async () => {
+    if (!user) return;
+    setLoading(true);
+    try {
+      const token = await requestPushPermission();
+      const db = getFirestore(getApp());
+      await setDoc(
+        doc(db, 'adminPushTokens', user.uid),
+        { expoPushToken: token, updatedAt: serverTimestamp() },
+        { merge: true }
+      );
+      Alert.alert('Éxito', 'Token guardado');
+    } catch (err) {
+      Alert.alert('Error', 'No se pudo registrar el token');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Button title={loading ? 'Guardando...' : 'Registrar mis notificaciones'} onPress={registerToken} disabled={loading} />
+    </View>
+  );
+};
+
+export default AdminScreen;

--- a/src/screens/AfiliateScreen.tsx
+++ b/src/screens/AfiliateScreen.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { View, TextInput, Button, Alert, StyleSheet } from 'react-native';
+import { useForm, Controller } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+import { getFirestore, collection, addDoc, serverTimestamp } from '@react-native-firebase/firestore';
+import { sendPushToAdmins } from '../services/sendPushToAdmins';
+
+interface FormData {
+  nombreApellido: string;
+  dni: string;
+  sector: string;
+  telefono: string;
+}
+
+const schema = yup.object({
+  nombreApellido: yup.string().required().min(3),
+  dni: yup.string().required().matches(/^\d{7,8}$/),
+  sector: yup.string().required(),
+  telefono: yup.string().required().matches(/^\+54 9 \d{2} \d{4}-\d{4}$/),
+});
+
+const AfiliateScreen: React.FC = () => {
+  const { control, handleSubmit, reset } = useForm<FormData>({
+    resolver: yupResolver(schema),
+  });
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      const db = getFirestore();
+      await addDoc(collection(db, 'affiliateRequests'), {
+        ...data,
+        status: 'pending',
+        createdAt: serverTimestamp(),
+      });
+      await sendPushToAdmins({
+        title: 'Nueva solicitud',
+        body: `De ${data.nombreApellido}`,
+      });
+      Alert.alert('Éxito', 'Solicitud enviada');
+      reset();
+    } catch (err) {
+      Alert.alert('Error', 'No se pudo enviar la solicitud');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Controller
+        control={control}
+        name="nombreApellido"
+        render={({ field: { onChange, value } }) => (
+          <TextInput
+            style={styles.input}
+            placeholder="Nombre y Apellido"
+            value={value}
+            onChangeText={onChange}
+          />
+        )}
+      />
+      <Controller
+        control={control}
+        name="dni"
+        render={({ field: { onChange, value } }) => (
+          <TextInput
+            style={styles.input}
+            placeholder="DNI"
+            keyboardType="number-pad"
+            value={value}
+            onChangeText={onChange}
+          />
+        )}
+      />
+      <Controller
+        control={control}
+        name="sector"
+        render={({ field: { onChange, value } }) => (
+          <TextInput
+            style={styles.input}
+            placeholder="Sector"
+            value={value}
+            onChangeText={onChange}
+          />
+        )}
+      />
+      <Controller
+        control={control}
+        name="telefono"
+        render={({ field: { onChange, value } }) => (
+          <TextInput
+            style={styles.input}
+            placeholder="Teléfono"
+            keyboardType="phone-pad"
+            value={value}
+            onChangeText={onChange}
+          />
+        )}
+      />
+      <Button title="Enviar" onPress={handleSubmit(onSubmit)} />
+    </View>
+  );
+};
+
+export default AfiliateScreen;
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    padding: 8,
+    marginBottom: 12,
+  },
+});

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -1,0 +1,10 @@
+import * as Notifications from 'expo-notifications';
+
+export const requestPushPermission = async (): Promise<string> => {
+  const { status } = await Notifications.requestPermissionsAsync();
+  if (status !== 'granted') {
+    throw new Error('Permiso denegado');
+  }
+  const token = await Notifications.getExpoPushTokenAsync();
+  return token.data;
+};

--- a/src/services/sendPushToAdmins.ts
+++ b/src/services/sendPushToAdmins.ts
@@ -1,0 +1,37 @@
+import { getFirestore, collection, getDocs } from '@react-native-firebase/firestore';
+import { chunkArray } from '../utils/chunkArray';
+
+interface Message {
+  title: string;
+  body: string;
+}
+
+export const sendPushToAdmins = async (msg: Message) => {
+  const db = getFirestore();
+  const snap = await getDocs(collection(db, 'adminPushTokens'));
+  const tokens = snap.docs
+    .map(d => d.data().expoPushToken as string)
+    .filter(Boolean);
+
+  if (!tokens.length) return;
+
+  const groups = chunkArray(tokens, 100);
+  for (const group of groups) {
+    const messages = group.map(token => ({
+      to: token,
+      sound: 'default',
+      title: msg.title,
+      body: msg.body,
+      data: { type: 'affiliateRequest' },
+    }));
+    try {
+      await fetch('https://exp.host/--/api/v2/push/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(messages),
+      });
+    } catch (err) {
+      console.error('Error enviando push', err);
+    }
+  }
+};

--- a/src/utils/__tests__/chunkArray.test.ts
+++ b/src/utils/__tests__/chunkArray.test.ts
@@ -1,0 +1,8 @@
+import { chunkArray } from '../chunkArray';
+
+describe('chunkArray', () => {
+  it('chunks array into smaller arrays', () => {
+    const result = chunkArray([1,2,3,4,5], 2);
+    expect(result).toEqual([[1,2],[3,4],[5]]);
+  });
+});

--- a/src/utils/chunkArray.ts
+++ b/src/utils/chunkArray.ts
@@ -1,0 +1,7 @@
+export function chunkArray<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
 
     "moduleResolution": "bundler",
 
-    "types": ["react", "react-native"],
+    "types": ["react", "react-native", "jest"],
     "noEmit": true,
 
     "baseUrl": "./",


### PR DESCRIPTION
## Summary
- add AfiliateScreen to send affiliate requests and notify admins
- create AdminScreen to register Expo push tokens
- implement push helpers and chunkArray utility with tests
- expose `isAdmin` in AuthContext and update tab navigation
- store admin tokens in App only for admins
- document push setup and rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c70e0a8088324b83d6bf3086cccc2