### PR TITLE
Use auth service during registration

### DIFF
--- a/src/screens/auth/RegisterScreen.tsx
+++ b/src/screens/auth/RegisterScreen.tsx
@@ -9,7 +9,8 @@ import {
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 // Modular API
-import { getAuth, createUserWithEmailAndPassword, updateProfile } from '@react-native-firebase/auth';
+import { updateProfile } from '@react-native-firebase/auth';
+import authService from '../../services/authService';
 
 const RegisterScreen: React.FC = () => {
   const navigation = useNavigation();
@@ -21,12 +22,12 @@ const RegisterScreen: React.FC = () => {
 
   const handleRegister = async () => {
     try {
-      const auth = getAuth();
-      const cred = await createUserWithEmailAndPassword(
-        auth,
-        email.trim(),
-        password
-      );
+      const cred = await authService.signUp(email.trim(), password, {
+        displayName,
+        affiliationNumber,
+        province,
+        status: 'pending',
+      });
       await updateProfile(cred.user, { displayName });
 
       Alert.alert('Registro exitoso', 'Ahora puedes iniciar sesión.');


### PR DESCRIPTION
## Summary
- register screen uses authService to sign up users

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_686087eedb9083248bff506e9ebd2dda