### PR TITLE
Add YouTube video screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "expo-linear-gradient": "~14.0.2",
         "expo-notifications": "~0.29.14",
         "expo-status-bar": "~2.0.1",
+        "fast-xml-parser": "^4.5.3",
         "firebase-admin": "^13.4.0",
         "lucide-react": "^0.477.0",
         "react": "18.3.1",
@@ -9223,7 +9224,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "strnum": "^1.1.1"
       },
@@ -16642,8 +16642,7 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/structured-headers": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.5",
+    "fast-xml-parser": "^4.5.3",
     "yup": "^1.6.1",
     "zustand": "^5.0.3"
   },

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -5,6 +5,7 @@ import { createStackNavigator } from '@react-navigation/stack';
 import TabNavigator from './TabNavigator';
 import BenefitDetailScreen from '../screens/benefits/BenefitDetailScreen';
 import NewsDetailScreen from '../screens/news/NewsDetailScreen';
+import YouTubeVideoScreen from '../screens/videos/YouTubeVideoScreen';
 import { View, Text } from 'react-native';
 
 // ✅ Import centralizado del tipo RootStackParamList
@@ -23,6 +24,7 @@ const AppNavigator: React.FC = () => {
         <Stack.Screen name="Main" component={TabNavigator} />
         <Stack.Screen name="BenefitDetail" component={BenefitDetailScreen} />
         <Stack.Screen name="NewsDetail" component={NewsDetailScreen} />
+        <Stack.Screen name="YouTubeVideo" component={YouTubeVideoScreen} />
       </Stack.Navigator>
     );
   } catch (error: any) {

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -13,6 +13,7 @@ import ProfileScreen from "../screens/profile/ProfileScreen";
 import ContactScreen from "../screens/contact/ContactScreen";
 import AfiliateScreen from "../screens/AfiliateScreen";
 import AdminScreen from "../screens/AdminScreen";
+import YouTubeChannelScreen from "../screens/videos/YouTubeChannelScreen";
 import { useAuth } from "../context/AuthContext";
 
 const Tab = createBottomTabNavigator();
@@ -36,6 +37,7 @@ const TabNavigator = () => {
           if (route.name === "Profile") iconName = "person-outline";
           if (route.name === "Contact") iconName = "logo-whatsapp";
           if (route.name === "Afiliate") iconName = "person-add-outline";
+          if (route.name === "Videos") iconName = "logo-youtube";
           if (route.name === "Admin") iconName = "settings-outline";
 
           // Fix 1: Forzar cast del iconName si TS no lo reconoce:
@@ -62,6 +64,12 @@ const TabNavigator = () => {
         name="Benefits"
         component={BenefitsListScreen}
         options={{ title: "Beneficios" }}
+      />
+
+      <Tab.Screen
+        name="Videos"
+        component={YouTubeChannelScreen}
+        options={{ title: "Videos" }}
       />
 
       <Tab.Screen

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -37,7 +37,7 @@ const TabNavigator = () => {
           if (route.name === "Profile") iconName = "person-outline";
           if (route.name === "Contact") iconName = "logo-whatsapp";
           if (route.name === "Afiliate") iconName = "person-add-outline";
-          if (route.name === "Videos") iconName = "logo-youtube";
+          if (route.name === "YouTubeChannel") iconName = "logo-youtube";
           if (route.name === "Admin") iconName = "settings-outline";
 
           // Fix 1: Forzar cast del iconName si TS no lo reconoce:
@@ -67,7 +67,7 @@ const TabNavigator = () => {
       />
 
       <Tab.Screen
-        name="Videos"
+        name="YouTubeChannel"
         component={YouTubeChannelScreen}
         options={{ title: "Videos" }}
       />

--- a/src/screens/videos/YouTubeChannelScreen.tsx
+++ b/src/screens/videos/YouTubeChannelScreen.tsx
@@ -12,7 +12,7 @@ import {
   StyleSheet,
   Alert,
 } from 'react-native';
-import { parse } from 'fast-xml-parser';
+import { XMLParser } from 'fast-xml-parser';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../../types/RootStackParamList';
@@ -55,7 +55,8 @@ export default function YouTubeChannelScreen() {
         `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`
       );
       const xml = await rssRes.text();
-      const json = parse(xml, { ignoreAttributes: false, attributeNamePrefix: '' });
+      const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '' });
+      const json = parser.parse(xml);
       const items = (json.feed?.entry ?? []) as any[];
 
       const mapped = items.map(e => ({

--- a/src/screens/videos/YouTubeChannelScreen.tsx
+++ b/src/screens/videos/YouTubeChannelScreen.tsx
@@ -24,13 +24,11 @@ interface VideoItem {
   published: string;
 }
 
-const CHANNEL_HANDLE_URL =
-  'https://www.youtube.com/@labancariaprensaydifusion9027';
-
-const extractChannelId = (html: string): string | null => {
-  const match = html.match(/"channelId":"(UC[\w-]{22})"/);
-  return match ? match[1] : null;
-};
+/**
+ * Channel ID of @labancariaprensaydifusion9027. Using the ID directly
+ * avoids an extra network request and potential parsing issues.
+ */
+const CHANNEL_ID = 'UC-rMO27hUU1HoPK7rH4DFlw';
 
 type Nav = NativeStackNavigationProp<RootStackParamList, 'YouTubeVideo'>;
 
@@ -43,16 +41,9 @@ export default function YouTubeChannelScreen() {
   const fetchVideos = useCallback(async () => {
     try {
       setRefreshing(true);
-      const htmlRes = await fetch(CHANNEL_HANDLE_URL);
-      const html = await htmlRes.text();
-      const channelId = extractChannelId(html);
-
-      if (!channelId) {
-        throw new Error('No se pudo obtener el channelId del canal.');
-      }
 
       const rssRes = await fetch(
-        `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`
+        `https://www.youtube.com/feeds/videos.xml?channel_id=${CHANNEL_ID}`
       );
       const xml = await rssRes.text();
       const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '' });

--- a/src/screens/videos/YouTubeChannelScreen.tsx
+++ b/src/screens/videos/YouTubeChannelScreen.tsx
@@ -13,10 +13,9 @@ import {
   Alert,
 } from 'react-native';
 import { parse } from 'fast-xml-parser';
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { RootStackParamList } from '../../types/RootStackParamList';
-
-type Props = NativeStackScreenProps<RootStackParamList, 'YouTubeChannel'>;
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../../types/RootStackParamList';
 
 interface VideoItem {
   id: string;
@@ -33,7 +32,10 @@ const extractChannelId = (html: string): string | null => {
   return match ? match[1] : null;
 };
 
-export default function YouTubeChannelScreen({ navigation }: Props) {
+type Nav = NativeStackNavigationProp<RootStackParamList, 'YouTubeVideo'>;
+
+export default function YouTubeChannelScreen() {
+  const navigation = useNavigation<Nav>();
   const [videos, setVideos] = useState<VideoItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);

--- a/src/screens/videos/YouTubeChannelScreen.tsx
+++ b/src/screens/videos/YouTubeChannelScreen.tsx
@@ -1,0 +1,128 @@
+// src/screens/videos/YouTubeChannelScreen.tsx
+
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  FlatList,
+  Image,
+  View,
+  Text,
+  TouchableOpacity,
+  ActivityIndicator,
+  RefreshControl,
+  StyleSheet,
+  Alert,
+} from 'react-native';
+import { parse } from 'fast-xml-parser';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../types/RootStackParamList';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'YouTubeChannel'>;
+
+interface VideoItem {
+  id: string;
+  title: string;
+  thumbnail: string;
+  published: string;
+}
+
+const CHANNEL_HANDLE_URL =
+  'https://www.youtube.com/@labancariaprensaydifusion9027';
+
+const extractChannelId = (html: string): string | null => {
+  const match = html.match(/"channelId":"(UC[\w-]{22})"/);
+  return match ? match[1] : null;
+};
+
+export default function YouTubeChannelScreen({ navigation }: Props) {
+  const [videos, setVideos] = useState<VideoItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchVideos = useCallback(async () => {
+    try {
+      setRefreshing(true);
+      const htmlRes = await fetch(CHANNEL_HANDLE_URL);
+      const html = await htmlRes.text();
+      const channelId = extractChannelId(html);
+
+      if (!channelId) {
+        throw new Error('No se pudo obtener el channelId del canal.');
+      }
+
+      const rssRes = await fetch(
+        `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`
+      );
+      const xml = await rssRes.text();
+      const json = parse(xml, { ignoreAttributes: false, attributeNamePrefix: '' });
+      const items = (json.feed?.entry ?? []) as any[];
+
+      const mapped = items.map(e => ({
+        id: e['yt:videoId'],
+        title: e.title,
+        thumbnail: Array.isArray(e['media:group']['media:thumbnail'])
+          ? e['media:group']['media:thumbnail'][0].url
+          : e['media:group']['media:thumbnail'].url,
+        published: e.published,
+      }));
+
+      setVideos(mapped);
+    } catch (err) {
+      console.error('Error al cargar videos', err);
+      Alert.alert('Error', 'No se pudieron cargar los videos.');
+    } finally {
+      setRefreshing(false);
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchVideos();
+  }, [fetchVideos]);
+
+  if (loading) {
+    return <ActivityIndicator style={{ flex: 1 }} size="large" />;
+  }
+
+  return (
+    <FlatList
+      data={videos}
+      keyExtractor={v => v.id}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={fetchVideos} />
+      }
+      contentContainerStyle={styles.list}
+      renderItem={({ item }) => (
+        <TouchableOpacity
+          style={styles.card}
+          onPress={() => navigation.navigate('YouTubeVideo', { videoId: item.id })}
+        >
+          <Image source={{ uri: item.thumbnail }} style={styles.thumb} />
+          <View style={styles.info}>
+            <Text style={styles.title} numberOfLines={2}>
+              {item.title}
+            </Text>
+            <Text style={styles.date}>
+              {new Date(item.published).toLocaleDateString()}
+            </Text>
+          </View>
+        </TouchableOpacity>
+      )}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  list: { padding: 12 },
+  card: {
+    flexDirection: 'row',
+    marginBottom: 12,
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    elevation: 2,
+    overflow: 'hidden',
+  },
+  thumb: { width: 130, height: 90 },
+  info: { flex: 1, padding: 8, justifyContent: 'center' },
+  title: { fontWeight: 'bold', fontSize: 15 },
+  date: { marginTop: 4, color: '#666', fontSize: 12 },
+});

--- a/src/screens/videos/YouTubeVideoScreen.tsx
+++ b/src/screens/videos/YouTubeVideoScreen.tsx
@@ -3,8 +3,10 @@
 import React from 'react';
 import { ActivityIndicator, StyleSheet } from 'react-native';
 import { WebView } from 'react-native-webview';
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { RootStackParamList } from '../../types/RootStackParamList';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../../types/RootStackParamList';
+
+// Ajustá la ruta si tu archivo de tipos está en otra ubicación
 
 type Props = NativeStackScreenProps<RootStackParamList, 'YouTubeVideo'>;
 
@@ -14,13 +16,14 @@ export default function YouTubeVideoScreen({ route }: Props) {
   return (
     <WebView
       source={{ uri: `https://www.youtube.com/embed/${videoId}` }}
-      allowsFullscreenVideo
+      style={{ flex: 1 }}
       startInLoadingState
-      renderLoading={() => <ActivityIndicator style={styles.loader} size="large" />}
+      renderLoading={() => <ActivityIndicator style={styles.loader} />}
+      allowsFullscreenVideo
     />
   );
 }
 
 const styles = StyleSheet.create({
-  loader: { flex: 1 },
+  loader: { flex: 1, justifyContent: 'center' },
 });

--- a/src/screens/videos/YouTubeVideoScreen.tsx
+++ b/src/screens/videos/YouTubeVideoScreen.tsx
@@ -1,0 +1,26 @@
+// src/screens/videos/YouTubeVideoScreen.tsx
+
+import React from 'react';
+import { ActivityIndicator, StyleSheet } from 'react-native';
+import { WebView } from 'react-native-webview';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../types/RootStackParamList';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'YouTubeVideo'>;
+
+export default function YouTubeVideoScreen({ route }: Props) {
+  const { videoId } = route.params;
+
+  return (
+    <WebView
+      source={{ uri: `https://www.youtube.com/embed/${videoId}` }}
+      allowsFullscreenVideo
+      startInLoadingState
+      renderLoading={() => <ActivityIndicator style={styles.loader} size="large" />}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  loader: { flex: 1 },
+});

--- a/src/types/RootStackParamList.ts
+++ b/src/types/RootStackParamList.ts
@@ -19,4 +19,8 @@ export type RootStackParamList = {
   BenefitDetail: { url: string };
   // NewsDetail recibe un objeto newsItem
   NewsDetail: { newsItem: NewsItem };
+  // Pantalla con el listado de videos del canal
+  YouTubeChannel: undefined;
+  // Pantalla que muestra un video específico
+  YouTubeVideo: { videoId: string };
 };


### PR DESCRIPTION
## Summary
- add YouTube channel screen and video player
- hook screens into navigation and types
- add bottom tab for videos
- install `fast-xml-parser` for RSS parsing

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.*)*

------
https://chatgpt.com/codex/tasks/task_e_68646161fd988324bef359896611989e