### PR TITLE
Add YouTubeChannel route

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "env": {
     "browser": true,
     "es2021": true
@@ -21,8 +21,14 @@
     "@typescript-eslint"
   ],
   "rules": {
-    "semi": ["error", "always"],
-    "quotes": ["error", "single"],
+    "semi": [
+      "error",
+      "always"
+    ],
+    "quotes": [
+      "error",
+      "single"
+    ],
     "react/react-in-jsx-scope": "off"
   }
-}
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint . --ext ts,tsx",
+    "lint": "npx -y eslint@8 -c .eslintrc.cjs . --ext ts,tsx",
     "test": "jest"
   },
   "dependencies": {

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -13,6 +13,7 @@ import ProfileScreen from "../screens/profile/ProfileScreen";
 import ContactScreen from "../screens/contact/ContactScreen";
 import AfiliateScreen from "../screens/AfiliateScreen";
 import AdminScreen from "../screens/AdminScreen";
+import YouTubeChannelScreen from "../screens/youtube/YouTubeChannelScreen";
 import { useAuth } from "../context/AuthContext";
 
 const Tab = createBottomTabNavigator();
@@ -35,6 +36,7 @@ const TabNavigator = () => {
 
           if (route.name === "Profile") iconName = "person-outline";
           if (route.name === "Contact") iconName = "logo-whatsapp";
+          if (route.name === "YouTubeChannel") iconName = "logo-youtube";
           if (route.name === "Afiliate") iconName = "person-add-outline";
           if (route.name === "Admin") iconName = "settings-outline";
 
@@ -62,6 +64,12 @@ const TabNavigator = () => {
         name="Benefits"
         component={BenefitsListScreen}
         options={{ title: "Beneficios" }}
+      />
+
+      <Tab.Screen
+        name="YouTubeChannel"
+        component={YouTubeChannelScreen}
+        options={{ title: "Videos" }}
       />
 
       <Tab.Screen

--- a/src/screens/youtube/YouTubeChannelScreen.tsx
+++ b/src/screens/youtube/YouTubeChannelScreen.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { WebView } from 'react-native-webview';
+
+const YouTubeChannelScreen: React.FC = () => {
+  return <WebView source={{ uri: 'https://www.youtube.com/' }} />;
+};
+
+export default YouTubeChannelScreen;
+


### PR DESCRIPTION
## Summary
- add new YouTubeChannelScreen and show in bottom tabs
- display a YouTube icon and rename route
- update lint script to pin eslint v8

## Testing
- `npm test`
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_68647a1091788324b407d680bceddc6e