### PR TITLE
feat(theme): centralize color palette

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,30 +1,80 @@
-// Ruta: src/screens/HomeScreen.tsx
-import React from 'react';
-import { SafeAreaView } from 'react-native-safe-area-context'; // Importamos SafeAreaView
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
-import { StatusBar } from 'expo-status-bar';
-
-const HomeScreen: React.FC = () => {
-  return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <LinearGradient colors={['#4c669f', '#3b5998', '#192f6a']} style={styles.container}>
-        <StatusBar style="light" />
-        <ScrollView contentContainerStyle={styles.content}>
-          <Text style={styles.title}>Bienvenido a Bancapp</Text>
-          <Text style={styles.subtitle}>Información Relevante</Text>
-          <Text style={styles.info}>
-            Aquí puedes mostrar la información más relevante de la aplicación, noticias, estadísticas o cualquier dato importante
-            que desees destacar para el usuario.
-          </Text>
-        </ScrollView>
-      </LinearGradient>
-    </SafeAreaView>
-  );
-};
-
-export default HomeScreen;
-
+// Ruta: src/screens/HomeScreen.tsx
+
+import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context'; // Importamos SafeAreaView
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { StatusBar } from 'expo-status-bar';
+import * as colors from '../theme/colors';
+
+const HomeScreen: React.FC = () => {
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <LinearGradient
+        colors={[
+          colors.homeGradientStart,
+          colors.homeGradientMiddle,
+          colors.homeGradientEnd,
+        ]}
+        style={styles.container}
+      >
+        <StatusBar style="light" />
+
+        <ScrollView contentContainerStyle={styles.content}>
+          <Text style={styles.title}>Bienvenido a Bancapp</Text>
+
+          <Text style={styles.subtitle}>Información Relevante</Text>
+
+          <Text style={styles.info}>
+            Aquí puedes mostrar la información más relevante de la aplicación,
+            noticias, estadísticas o cualquier dato importante que desees
+            destacar para el usuario.
+          </Text>
+        </ScrollView>
+      </LinearGradient>
+    </SafeAreaView>
+  );
+};
+
+export default HomeScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+
+  content: {
+    padding: 20,
+
+    alignItems: 'center',
+
+    justifyContent: 'center',
+  },
+
+  title: {
+    fontSize: 32,
+
+    fontWeight: 'bold',
+
+    color: colors.white,
+    marginBottom: 10,
+  },
+
+  subtitle: {
+    fontSize: 18,
+
+    color: colors.lightGray,
+    marginBottom: 20,
+  },
+
+  info: {
+    fontSize: 16,
+
+    color: colors.white,
+    textAlign: 'center',
+  },
+});
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -12,6 +12,7 @@ import {
 import { LinearGradient } from 'expo-linear-gradient';
 import { useAuth } from '../../context/AuthContext';
 import { useNavigation } from '@react-navigation/native';
+import * as colors from '../../theme/colors';
 
 const { width } = Dimensions.get('window');
 
@@ -63,7 +64,7 @@ const LoginScreen: React.FC = () => {
               <TextInput
                 style={styles.input}
                 placeholder="Correo"
-                placeholderTextColor="#999999"
+                placeholderTextColor={colors.placeholder}
                 value={email}
                 onChangeText={setEmail}
                 keyboardType="email-address"
@@ -74,7 +75,7 @@ const LoginScreen: React.FC = () => {
               <TextInput
                 style={styles.input}
                 placeholder="Contraseña"
-                placeholderTextColor="#999999"
+                placeholderTextColor={colors.placeholder}
                 value={password}
                 onChangeText={setPassword}
                 secureTextEntry
@@ -90,7 +91,7 @@ const LoginScreen: React.FC = () => {
                 onPress={handleLogin}
               >
                 <LinearGradient
-                  colors={['#4caf50', '#388e3c']}
+                  colors={[colors.primary, colors.primaryDark]}
                   style={styles.buttonGradient}
                   start={{ x: 0, y: 0 }}
                   end={{ x: 0, y: 1 }}
@@ -104,7 +105,7 @@ const LoginScreen: React.FC = () => {
                 onPress={handleSignUp}
               >
                 <LinearGradient
-                  colors={['#2196f3', '#1976d2']}
+                  colors={[colors.secondary, colors.secondaryDark]}
                   style={styles.buttonGradient}
                   start={{ x: 0, y: 0 }}
                   end={{ x: 0, y: 1 }}
@@ -118,7 +119,7 @@ const LoginScreen: React.FC = () => {
       </ImageBackground>
     );
   } catch (error: any) {
-    console.error("Error en LoginScreen:", error);
+    console.error('Error en LoginScreen:', error);
     return (
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
         <Text style={{ color: 'red', fontSize: 20, textAlign: 'center' }}>
@@ -154,7 +155,7 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 28,
     fontWeight: 'bold',
-    color: '#FFFFFF',
+    color: colors.white,
     textShadowColor: 'rgba(0,0,0,0.5)',
     textShadowOffset: { width: 2, height: 2 },
     textShadowRadius: 4,
@@ -173,16 +174,16 @@ const styles = StyleSheet.create({
     padding: 12,
     borderRadius: 25,
     fontSize: 16,
-    backgroundColor: '#FFFFFF',
-    color: '#2D3436',
-    shadowColor: '#000',
+    backgroundColor: colors.white,
+    color: colors.text,
+    shadowColor: colors.black,
     shadowOffset: { width: 2, height: 2 },
     shadowOpacity: 0.2,
     shadowRadius: 5,
     elevation: 3,
   },
   forgotPassword: {
-    color: '#cceeff',
+    color: colors.link,
     fontSize: 14,
     marginTop: 5,
     textDecorationLine: 'underline',
@@ -197,7 +198,7 @@ const styles = StyleSheet.create({
     borderRadius: 25,
     overflow: 'hidden',
     marginHorizontal: 5,
-    shadowColor: '#000',
+    shadowColor: colors.black,
     shadowOffset: { width: 4, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,
@@ -211,6 +212,6 @@ const styles = StyleSheet.create({
   buttonText: {
     fontSize: 16,
     fontWeight: 'bold',
-    color: '#FFFFFF',
+    color: colors.white,
   },
 });

--- a/src/screens/contact/ContactScreen.tsx
+++ b/src/screens/contact/ContactScreen.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Linking } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Linking,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { FontAwesome } from '@expo/vector-icons';
+import * as colors from '../../theme/colors';
 
 const numero = '5491158178508'; // Sin el +
 const mensaje = 'Hola, me quiero contactar con alguien de la gremial.';
@@ -17,13 +24,19 @@ const ContactScreen: React.FC = () => {
       <View style={styles.content}>
         <Text style={styles.title}>Contacto Gremial</Text>
         <Text style={styles.subtitle}>
-          Si necesitás ayuda o querés comunicarte con la gremial, presioná el botón de WhatsApp abajo.
+          Si necesitás ayuda o querés comunicarte con la gremial, presioná el
+          botón de WhatsApp abajo.
         </Text>
       </View>
 
       <View style={styles.bottomBar}>
         <TouchableOpacity style={styles.whatsappButton} onPress={abrirWhatsApp}>
-          <FontAwesome name="whatsapp" size={24} color="#fff" style={{ marginRight: 8 }} />
+          <FontAwesome
+            name="whatsapp"
+            size={24}
+            color={colors.white}
+            style={{ marginRight: 8 }}
+          />
           <Text style={styles.buttonText}>Contactar por WhatsApp</Text>
         </TouchableOpacity>
       </View>
@@ -36,7 +49,7 @@ export default ContactScreen;
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
+    backgroundColor: colors.white,
     justifyContent: 'space-between',
   },
   content: {
@@ -53,33 +66,33 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontSize: 16,
-    color: '#555',
+    color: colors.gray,
     textAlign: 'center',
   },
   bottomBar: {
     width: '100%',
     padding: 16,
-    backgroundColor: '#fff',
+    backgroundColor: colors.white,
     borderTopWidth: 1,
-    borderTopColor: '#eee',
+    borderTopColor: colors.lightGray,
     alignItems: 'center',
     justifyContent: 'center',
   },
   whatsappButton: {
     flexDirection: 'row',
-    backgroundColor: '#25D366',
+    backgroundColor: colors.whatsapp,
     paddingVertical: 14,
     paddingHorizontal: 24,
     borderRadius: 30,
     alignItems: 'center',
     elevation: 2,
-    shadowColor: '#000',
+    shadowColor: colors.black,
     shadowOpacity: 0.2,
     shadowOffset: { width: 0, height: 2 },
     shadowRadius: 4,
   },
   buttonText: {
-    color: '#fff',
+    color: colors.white,
     fontSize: 16,
     fontWeight: 'bold',
   },

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,0 +1,55 @@
+export const primary = '#4caf50';
+export const primaryDark = '#388e3c';
+export const secondary = '#2196f3';
+export const secondaryDark = '#1976d2';
+export const background = '#FFFFFF';
+export const text = '#2D3436';
+export const placeholder = '#999999';
+export const link = '#cceeff';
+export const white = '#FFFFFF';
+export const black = '#000000';
+export const homeGradientStart = '#4c669f';
+export const homeGradientMiddle = '#3b5998';
+export const homeGradientEnd = '#192f6a';
+export const lightGray = '#EEEEEE';
+export const gray = '#555555';
+export const whatsapp = '#25D366';
+export const blue = '#007AFF';
+export const blueLight = '#007bff';
+export const infoBlue = '#2E86C1';
+export const chipBlue = '#2f5cff';
+export const darkGray = '#333333';
+export const mediumGray = '#666666';
+export const borderGray = '#cccccc';
+export const chipBackground = '#eef4ff';
+export const lightBackground = '#f0f2f5';
+export const offWhite = '#f5f5f5';
+
+export default {
+  primary,
+  primaryDark,
+  secondary,
+  secondaryDark,
+  background,
+  text,
+  placeholder,
+  link,
+  white,
+  black,
+  homeGradientStart,
+  homeGradientMiddle,
+  homeGradientEnd,
+  lightGray,
+  gray,
+  whatsapp,
+  blue,
+  blueLight,
+  infoBlue,
+  chipBlue,
+  darkGray,
+  mediumGray,
+  borderGray,
+  chipBackground,
+  lightBackground,
+  offWhite,
+};


### PR DESCRIPTION
## Summary
- add `src/theme/colors.ts` with shared color constants
- replace hardcoded hex colors in Login, Home, and Contact screens to use the theme palette
- collect additional color constants for other hex codes found in the project

## Testing
- `npm test`
- `ESLINT_USE_FLAT_CONFIG=false npm run lint` *(fails: Strings must use singlequote, Unexpected any, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c56ccbb7208324b8b66d26a8944d5c