### PR TITLE
feat: add typography system

### DIFF
--- a/src/components/AppText.tsx
+++ b/src/components/AppText.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Text, TextProps } from 'react-native';
+import { typography, TypographyVariant } from '../theme/typography';
+
+interface AppTextProps extends TextProps {
+  variant?: TypographyVariant;
+}
+
+const AppText: React.FC<AppTextProps> = ({ variant = 'body', style, ...rest }) => {
+  return <Text style={[typography[variant], style]} {...rest} />;
+};
+
+export default AppText;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,14 +1,26 @@
-// Ruta: src/screens/HomeScreen.tsx
-import React from 'react';
-import { SafeAreaView } from 'react-native-safe-area-context'; // Importamos SafeAreaView
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
-import { StatusBar } from 'expo-status-bar';
-
-const HomeScreen: React.FC = () => {
-  return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <LinearGradient colors={['#4c669f', '#3b5998', '#192f6a']} style={styles.container}>
+import { View, StyleSheet, ScrollView } from 'react-native';
+import AppText from '../components/AppText';
+import { typography } from '../theme/typography';
+          <AppText style={styles.title}>Bienvenido a Bancapp</AppText>
+          <AppText style={styles.subtitle}>Información Relevante</AppText>
+          <AppText style={styles.info}>
+          </AppText>
+  title: {
+    ...typography.heading1,
+    color: '#fff',
+    marginBottom: 10,
+  },
+  subtitle: {
+    ...typography.subtitle,
+    color: '#eee',
+    marginBottom: 20,
+  },
+  info: {
+    ...typography.body,
+    color: '#fff',
+    textAlign: 'center',
+  },
+});
         <StatusBar style="light" />
         <ScrollView contentContainerStyle={styles.content}>
           <Text style={styles.title}>Bienvenido a Bancapp</Text>

--- a/src/screens/contact/ContactScreen.tsx
+++ b/src/screens/contact/ContactScreen.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Linking } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, Linking } from 'react-native';
+import AppText from '../../components/AppText';
+import { typography } from '../../theme/typography';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { FontAwesome } from '@expo/vector-icons';
 
@@ -15,16 +17,16 @@ const ContactScreen: React.FC = () => {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.content}>
-        <Text style={styles.title}>Contacto Gremial</Text>
-        <Text style={styles.subtitle}>
+        <AppText style={styles.title}>Contacto Gremial</AppText>
+        <AppText style={styles.subtitle}>
           Si necesitás ayuda o querés comunicarte con la gremial, presioná el botón de WhatsApp abajo.
-        </Text>
+        </AppText>
       </View>
 
       <View style={styles.bottomBar}>
         <TouchableOpacity style={styles.whatsappButton} onPress={abrirWhatsApp}>
           <FontAwesome name="whatsapp" size={24} color="#fff" style={{ marginRight: 8 }} />
-          <Text style={styles.buttonText}>Contactar por WhatsApp</Text>
+          <AppText style={styles.buttonText}>Contactar por WhatsApp</AppText>
         </TouchableOpacity>
       </View>
     </SafeAreaView>
@@ -46,13 +48,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
   },
   title: {
-    fontSize: 24,
-    fontWeight: 'bold',
+    ...typography.heading2,
     marginBottom: 16,
     textAlign: 'center',
   },
   subtitle: {
-    fontSize: 16,
+    ...typography.body,
     color: '#555',
     textAlign: 'center',
   },
@@ -79,8 +80,7 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
   },
   buttonText: {
+    ...typography.button,
     color: '#fff',
-    fontSize: 16,
-    fontWeight: 'bold',
   },
 });

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,0 +1,24 @@
+export const fontSizes = {
+  heading1: 32,
+  heading2: 24,
+  subtitle: 18,
+  body: 16,
+  caption: 14,
+};
+
+export const fontWeights = {
+  regular: '400' as const,
+  medium: '500' as const,
+  bold: '700' as const,
+};
+
+export const typography = {
+  heading1: { fontSize: fontSizes.heading1, fontWeight: fontWeights.bold },
+  heading2: { fontSize: fontSizes.heading2, fontWeight: fontWeights.bold },
+  subtitle: { fontSize: fontSizes.subtitle, fontWeight: fontWeights.regular },
+  body: { fontSize: fontSizes.body, fontWeight: fontWeights.regular },
+  button: { fontSize: fontSizes.body, fontWeight: fontWeights.bold },
+  caption: { fontSize: fontSizes.caption, fontWeight: fontWeights.regular },
+};
+
+export type TypographyVariant = keyof typeof typography;


### PR DESCRIPTION
## Summary
- add centralized typography scale and weights
- create AppText component that applies default body style
- refactor Home and Contact screens to use shared typography

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68c56cc9d2208324b98aa701026c6ccd