### PR TITLE
refactor: extract inline styles to stylesheet

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from 'expo-status-bar';
 import { AuthProvider, useAuth } from './src/context/AuthContext';
 import RootNavigator from './src/navigation/RootNavigator';
 import { View, Text, Alert, Vibration } from 'react-native';
+import { globalStyles } from './src/theme/globalStyles';
 import * as Notifications from 'expo-notifications';
 import { getFirestore, doc, setDoc, serverTimestamp } from '@react-native-firebase/firestore';
 import { getApp } from '@react-native-firebase/app';
@@ -107,8 +108,8 @@ export default function App() {
   } catch (error: any) {
     console.error('Error en App:', error);
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <Text style={{ color: 'red', fontSize: 20, textAlign: 'center' }}>
+      <View style={globalStyles.centeredContainer}>
+        <Text style={globalStyles.errorText}>
           Ocurrió un error inesperado en la aplicación.
         </Text>
       </View>

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -7,6 +7,7 @@ import BenefitDetailScreen from '../screens/benefits/BenefitDetailScreen';
 import NewsDetailScreen from '../screens/news/NewsDetailScreen';
 import YouTubeVideoScreen from '../screens/videos/YouTubeVideoScreen';
 import { View, Text } from 'react-native';
+import { globalStyles } from '../theme/globalStyles';
 import ForceLogoutScreen from "../screens/ForceLogoutScreen";
 
 
@@ -34,8 +35,8 @@ const AppNavigator: React.FC = () => {
   } catch (error: any) {
     console.error("Error en AppNavigator:", error);
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <Text style={{ color: 'red', fontSize: 20, textAlign: 'center' }}>
+      <View style={globalStyles.centeredContainer}>
+        <Text style={globalStyles.errorText}>
           Ocurrió un error en la navegación principal.
         </Text>
       </View>
@@ -48,3 +49,4 @@ export default AppNavigator;
 /**
  * Si usás RootStackParamList en otros navegadores, siempre importalo de la misma fuente.
  */
+

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -4,6 +4,7 @@ import LoginScreen from '../screens/auth/LoginScreen';
 import RegisterScreen from '../screens/auth/RegisterScreen';
 import PasswordResetScreen from '../screens/auth/PasswordResetScreen';
 import { View, Text } from 'react-native'; // Import Text and View
+import { globalStyles } from '../theme/globalStyles';
 
 export type AuthStackParamList = {
   Login: undefined;
@@ -25,8 +26,8 @@ const AuthNavigator: React.FC = () => {
   } catch (error: any) {
     console.error("Error en AuthNavigator:", error);
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <Text style={{ color: 'red', fontSize: 20, textAlign: 'center' }}>
+      <View style={globalStyles.centeredContainer}>
+        <Text style={globalStyles.errorText}>
           Ocurrió un error en la navegación de autenticación.
         </Text>
       </View>

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ActivityIndicator, View, Text } from 'react-native'; // Import Text and View
+import { globalStyles } from '../theme/globalStyles';
 import { useAuth } from '../context/AuthContext';
 import AuthNavigator from './AuthNavigator';
 import AppNavigator from './AppNavigator';
@@ -9,7 +10,7 @@ const RootNavigator: React.FC = () => {
 
   if (loading) {
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <View style={globalStyles.centeredContainer}>
         <ActivityIndicator size="large" />
       </View>
     );
@@ -20,8 +21,8 @@ const RootNavigator: React.FC = () => {
   } catch (error: any) {
     console.error("Error en RootNavigator:", error);
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <Text style={{ color: 'red', fontSize: 20, textAlign: 'center' }}>
+      <View style={globalStyles.centeredContainer}>
+        <Text style={globalStyles.errorText}>
           Ocurrió un error en la navegación.
         </Text>
       </View>

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,5 +1,9 @@
-// Ruta: src/screens/HomeScreen.tsx
-import React from 'react';
+import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context'; // Importamos SafeAreaView
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { globalStyles } from '../theme/globalStyles';
+    <SafeAreaView style={globalStyles.flex1}>
+
 import { SafeAreaView } from 'react-native-safe-area-context'; // Importamos SafeAreaView
 import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -12,6 +12,7 @@ import {
 import { LinearGradient } from 'expo-linear-gradient';
 import { useAuth } from '../../context/AuthContext';
 import { useNavigation } from '@react-navigation/native';
+import { globalStyles } from '../../theme/globalStyles';
 
 const { width } = Dimensions.get('window');
 
@@ -120,8 +121,8 @@ const LoginScreen: React.FC = () => {
   } catch (error: any) {
     console.error("Error en LoginScreen:", error);
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <Text style={{ color: 'red', fontSize: 20, textAlign: 'center' }}>
+      <View style={globalStyles.centeredContainer}>
+        <Text style={globalStyles.errorText}>
           Ocurrió un error al cargar la pantalla de inicio de sesión.
         </Text>
       </View>
@@ -214,3 +215,4 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
   },
 });
+

--- a/src/screens/contact/ContactScreen.tsx
+++ b/src/screens/contact/ContactScreen.tsx
@@ -23,7 +23,7 @@ const ContactScreen: React.FC = () => {
 
       <View style={styles.bottomBar}>
         <TouchableOpacity style={styles.whatsappButton} onPress={abrirWhatsApp}>
-          <FontAwesome name="whatsapp" size={24} color="#fff" style={{ marginRight: 8 }} />
+          <FontAwesome name="whatsapp" size={24} color="#fff" style={styles.icon} />
           <Text style={styles.buttonText}>Contactar por WhatsApp</Text>
         </TouchableOpacity>
       </View>
@@ -78,6 +78,7 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 2 },
     shadowRadius: 4,
   },
+  icon: { marginRight: 8 },
   buttonText: {
     color: '#fff',
     fontSize: 16,

--- a/src/screens/videos/YouTubeVideoScreen.tsx
+++ b/src/screens/videos/YouTubeVideoScreen.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { ActivityIndicator, StyleSheet } from 'react-native';
+import { globalStyles } from '../../theme/globalStyles';
 import { WebView } from 'react-native-webview';
 import type { StackScreenProps } from '@react-navigation/stack';
 import type { RootStackParamList } from '../../types/RootStackParamList';
@@ -16,7 +17,7 @@ export default function YouTubeVideoScreen({ route }: Props) {
   return (
     <WebView
       source={{ uri: `https://www.youtube.com/embed/${videoId}` }}
-      style={{ flex: 1 }}
+      style={globalStyles.flex1}
       startInLoadingState
       renderLoading={() => <ActivityIndicator style={styles.loader} />}
       allowsFullscreenVideo
@@ -27,3 +28,4 @@ export default function YouTubeVideoScreen({ route }: Props) {
 const styles = StyleSheet.create({
   loader: { flex: 1, justifyContent: 'center' },
 });
+

--- a/src/theme/globalStyles.ts
+++ b/src/theme/globalStyles.ts
@@ -1,0 +1,18 @@
+import { StyleSheet } from 'react-native';
+
+export const globalStyles = StyleSheet.create({
+  flex1: {
+    flex: 1,
+  },
+  centeredContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  errorText: {
+    color: 'red',
+    fontSize: 20,
+    textAlign: 'center',
+  },
+});
+


### PR DESCRIPTION
## Summary
- centralize shared styles in new `globalStyles` module
- replace inline styles with StyleSheet references across app and navigation components
- add local StyleSheet rule for WhatsApp icon spacing

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68c56cc7551c83248038facf4ff1913b