### PR TITLE
feat(theme): centralize color palette

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,6 +1,10 @@
-// Ruta: src/screens/HomeScreen.tsx
-import React from 'react';
-import { SafeAreaView } from 'react-native-safe-area-context'; // Importamos SafeAreaView
+import { LinearGradient } from 'expo-linear-gradient';
+import { StatusBar } from 'expo-status-bar';
+import { gradientStart, gradientMiddle, gradientEnd, white, lightGray } from '../theme/colors';
+      <LinearGradient colors={[gradientStart, gradientMiddle, gradientEnd]} style={styles.container}>
+    color: white,
+    color: lightGray,
+    color: white,
 import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { StatusBar } from 'expo-status-bar';

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -12,6 +12,17 @@ import {
 import { LinearGradient } from 'expo-linear-gradient';
 import { useAuth } from '../../context/AuthContext';
 import { useNavigation } from '@react-navigation/native';
+import {
+  primary,
+  primaryDark,
+  secondary,
+  secondaryDark,
+  white,
+  text,
+  black,
+  lightBlue,
+  placeholder,
+} from '../../theme/colors';
 
 const { width } = Dimensions.get('window');
 
@@ -63,7 +74,7 @@ const LoginScreen: React.FC = () => {
               <TextInput
                 style={styles.input}
                 placeholder="Correo"
-                placeholderTextColor="#999999"
+                placeholderTextColor={placeholder}
                 value={email}
                 onChangeText={setEmail}
                 keyboardType="email-address"
@@ -74,7 +85,7 @@ const LoginScreen: React.FC = () => {
               <TextInput
                 style={styles.input}
                 placeholder="Contraseña"
-                placeholderTextColor="#999999"
+                placeholderTextColor={placeholder}
                 value={password}
                 onChangeText={setPassword}
                 secureTextEntry
@@ -90,7 +101,7 @@ const LoginScreen: React.FC = () => {
                 onPress={handleLogin}
               >
                 <LinearGradient
-                  colors={['#4caf50', '#388e3c']}
+                  colors={[secondary, secondaryDark]}
                   style={styles.buttonGradient}
                   start={{ x: 0, y: 0 }}
                   end={{ x: 0, y: 1 }}
@@ -104,7 +115,7 @@ const LoginScreen: React.FC = () => {
                 onPress={handleSignUp}
               >
                 <LinearGradient
-                  colors={['#2196f3', '#1976d2']}
+                  colors={[primary, primaryDark]}
                   style={styles.buttonGradient}
                   start={{ x: 0, y: 0 }}
                   end={{ x: 0, y: 1 }}
@@ -154,7 +165,7 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 28,
     fontWeight: 'bold',
-    color: '#FFFFFF',
+    color: white,
     textShadowColor: 'rgba(0,0,0,0.5)',
     textShadowOffset: { width: 2, height: 2 },
     textShadowRadius: 4,
@@ -173,16 +184,16 @@ const styles = StyleSheet.create({
     padding: 12,
     borderRadius: 25,
     fontSize: 16,
-    backgroundColor: '#FFFFFF',
-    color: '#2D3436',
-    shadowColor: '#000',
+    backgroundColor: white,
+    color: text,
+    shadowColor: black,
     shadowOffset: { width: 2, height: 2 },
     shadowOpacity: 0.2,
     shadowRadius: 5,
     elevation: 3,
   },
   forgotPassword: {
-    color: '#cceeff',
+    color: lightBlue,
     fontSize: 14,
     marginTop: 5,
     textDecorationLine: 'underline',
@@ -197,7 +208,7 @@ const styles = StyleSheet.create({
     borderRadius: 25,
     overflow: 'hidden',
     marginHorizontal: 5,
-    shadowColor: '#000',
+    shadowColor: black,
     shadowOffset: { width: 4, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,
@@ -211,6 +222,6 @@ const styles = StyleSheet.create({
   buttonText: {
     fontSize: 16,
     fontWeight: 'bold',
-    color: '#FFFFFF',
+    color: white,
   },
 });

--- a/src/screens/contact/ContactScreen.tsx
+++ b/src/screens/contact/ContactScreen.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Linking } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { FontAwesome } from '@expo/vector-icons';
+import { white, mediumGray, lightGray, whatsapp, black } from '../../theme/colors';
 
 const numero = '5491158178508'; // Sin el +
 const mensaje = 'Hola, me quiero contactar con alguien de la gremial.';
@@ -23,7 +24,7 @@ const ContactScreen: React.FC = () => {
 
       <View style={styles.bottomBar}>
         <TouchableOpacity style={styles.whatsappButton} onPress={abrirWhatsApp}>
-          <FontAwesome name="whatsapp" size={24} color="#fff" style={{ marginRight: 8 }} />
+          <FontAwesome name="whatsapp" size={24} color={white} style={{ marginRight: 8 }} />
           <Text style={styles.buttonText}>Contactar por WhatsApp</Text>
         </TouchableOpacity>
       </View>
@@ -36,7 +37,7 @@ export default ContactScreen;
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
+    backgroundColor: white,
     justifyContent: 'space-between',
   },
   content: {
@@ -53,33 +54,33 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     fontSize: 16,
-    color: '#555',
+    color: mediumGray,
     textAlign: 'center',
   },
   bottomBar: {
     width: '100%',
     padding: 16,
-    backgroundColor: '#fff',
+    backgroundColor: white,
     borderTopWidth: 1,
-    borderTopColor: '#eee',
+    borderTopColor: lightGray,
     alignItems: 'center',
     justifyContent: 'center',
   },
   whatsappButton: {
     flexDirection: 'row',
-    backgroundColor: '#25D366',
+    backgroundColor: whatsapp,
     paddingVertical: 14,
     paddingHorizontal: 24,
     borderRadius: 30,
     alignItems: 'center',
     elevation: 2,
-    shadowColor: '#000',
+    shadowColor: black,
     shadowOpacity: 0.2,
     shadowOffset: { width: 0, height: 2 },
     shadowRadius: 4,
   },
   buttonText: {
-    color: '#fff',
+    color: white,
     fontSize: 16,
     fontWeight: 'bold',
   },

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,0 +1,17 @@
+// Centralized color palette
+export const primary = '#2196f3';
+export const primaryDark = '#1976d2';
+export const secondary = '#4caf50';
+export const secondaryDark = '#388e3c';
+export const background = '#ffffff';
+export const text = '#2D3436';
+export const white = '#ffffff';
+export const black = '#000000';
+export const lightGray = '#eeeeee';
+export const mediumGray = '#555555';
+export const placeholder = '#999999';
+export const gradientStart = '#4c669f';
+export const gradientMiddle = '#3b5998';
+export const gradientEnd = '#192f6a';
+export const lightBlue = '#cceeff';
+export const whatsapp = '#25D366';


### PR DESCRIPTION
## Summary
- add shared color palette
- refactor screens to reuse palette

## Testing
- `rg "#[0-9a-fA-F]{3,6}" src/screens/auth/LoginScreen.tsx src/screens/HomeScreen.tsx src/screens/contact/ContactScreen.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c56a50b4a48324b73a2c7b9be58e3e