### PR TITLE
Add announcements tab and screen

### DIFF
--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -4,6 +4,7 @@ import { View, StyleSheet, Image } from 'react-native';
 import type { ViewStyle } from 'react-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Ionicons } from '@expo/vector-icons';
+import AnnouncementsScreen from '../screens/announcements/AnnouncementsScreen';
 import BenefitsListScreen from '../screens/benefits/BenefitsListScreen';
 import NewsListScreen from '../screens/news/NewsListScreen';
 import ProfileScreen from '../screens/profile/ProfileScreen';
@@ -32,13 +33,22 @@ const TabNavigator = () => {
   return (
     <View style={styles.container}>
       <Tab.Navigator screenOptions={screenOptions}>
+        <Tab.Screen
+          name="Announcements"
+          component={AnnouncementsScreen}
+          options={{ title: 'Comunicados', tabBarLabel: () => null }}
+        />
         <Tab.Screen name="NewsList" component={NewsListScreen} options={{ title: 'Noticias', tabBarLabel: () => null }} />
         <Tab.Screen name="Benefits" component={BenefitsListScreen} options={{ title: 'Beneficios', tabBarLabel: () => null }} />
         <Tab.Screen name="YouTubeChannel" component={YouTubeChannelScreen} options={{ title: '' }} />
-        <Tab.Screen name="SergioPalazzoInterviews" component={SergioPalazzoInterviewsScreen} options={{ title: 'Palazzo', tabBarLabel: () => null }} />
+        <Tab.Screen
+          name="SergioPalazzoInterviews"
+          component={SergioPalazzoInterviewsScreen}
+          options={{ title: 'Palazzo', tabBarLabel: () => null }}
+        />
         <Tab.Screen name="Afiliate" component={AfiliateScreen} options={{ title: 'Afiliate', tabBarLabel: () => null }} />
         <Tab.Screen name="Contact" component={ContactScreen} options={{ title: 'Contacto', tabBarLabel: () => null }} />
-                  <Tab.Screen name="Profile" component={ProfileScreen} options={{ title: 'Perfil', tabBarLabel: 'Perfil' }} />
+        <Tab.Screen name="Profile" component={ProfileScreen} options={{ title: 'Perfil', tabBarLabel: 'Perfil' }} />
 
         {isAdmin && <Tab.Screen name="Admin" component={AdminScreen} options={{ title: 'Admin', tabBarLabel: 'Admin' }} />}
       </Tab.Navigator>
@@ -76,6 +86,8 @@ const renderIcon = (src: any, focused: boolean) => (
 
 const iconForRoute = (routeName: string) => {
   switch (routeName) {
+    case 'Announcements':
+      return 'megaphone-outline';
     case 'Profile':
       return 'person-outline';
     case 'Admin':

--- a/src/screens/announcements/AnnouncementsScreen.tsx
+++ b/src/screens/announcements/AnnouncementsScreen.tsx
@@ -1,0 +1,433 @@
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Image,
+  Linking,
+  Pressable,
+  StyleSheet,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  collection,
+  getFirestore,
+  onSnapshot,
+  orderBy,
+  query,
+  type QuerySnapshot,
+  type DocumentData,
+} from '@react-native-firebase/firestore';
+import { LinearGradient } from 'expo-linear-gradient';
+import { getFirebaseApp } from '../../config/firebaseApp';
+import { useTheme } from '../../theme';
+import { spacing } from '../../theme/spacing';
+import AppText from '../../ui/AppText';
+import type { Announcement } from '../../types/RootStackParamList';
+
+const AnnouncementsScreen: React.FC = () => {
+  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+  const [loading, setLoading] = useState(true);
+  const t = useTheme();
+
+  const palette = useMemo(
+    () => ({
+      surface: t.colors.surface,
+      surfaceAlt: t.colors.surfaceAlt,
+      title: t.colors.onBackground,
+      muted: t.colors.muted,
+      accent: t.colors.primary,
+      accentOn: t.colors.onPrimary,
+    }),
+    [
+      t.colors.muted,
+      t.colors.onBackground,
+      t.colors.onPrimary,
+      t.colors.primary,
+      t.colors.surface,
+      t.colors.surfaceAlt,
+    ],
+  );
+
+  useEffect(() => {
+    const db = getFirestore(getFirebaseApp());
+    const announcementsRef = collection(db, 'announcements');
+    const announcementsQuery = query(announcementsRef, orderBy('createdAt', 'desc'));
+
+    const handleSnapshot = (snap: QuerySnapshot<DocumentData>) => {
+      const items = snap.docs.map(doc => ({
+        id: doc.id,
+        ...(doc.data() as Omit<Announcement, 'id'>),
+      }));
+      setAnnouncements(items as Announcement[]);
+      setLoading(false);
+    };
+
+    const unsubscribe = onSnapshot(
+      announcementsQuery,
+      handleSnapshot,
+      error => {
+        console.error('Error al obtener los comunicados:', error);
+        setLoading(false);
+      },
+    );
+
+    return () => unsubscribe();
+  }, []);
+
+  const getImageSource = useCallback((item: Announcement) => {
+    return item.imageUrl || item.img || item.image || undefined;
+  }, []);
+
+  const getAnnouncementUrl = useCallback((item: Announcement) => {
+    const candidate = item.fileUrl || item.link || item.url || item.imageUrl;
+    if (candidate && /^https?:\/\//i.test(candidate)) {
+      return candidate;
+    }
+    return null;
+  }, []);
+
+  const formatDate = useCallback((value: Announcement['createdAt']) => {
+    if (!value) {
+      return '';
+    }
+
+    try {
+      if (typeof value === 'object' && typeof (value as any).toDate === 'function') {
+        return (value as { toDate: () => Date }).toDate().toLocaleString('es-AR');
+      }
+
+      const date = value instanceof Date ? value : new Date(value);
+      if (Number.isNaN(date.getTime())) {
+        return '';
+      }
+      return date.toLocaleString('es-AR');
+    } catch (error) {
+      console.warn('No se pudo formatear la fecha del comunicado:', error);
+      return '';
+    }
+  }, []);
+
+  const handleOpen = useCallback(
+    (item: Announcement) => {
+      const url = getAnnouncementUrl(item);
+      if (!url) {
+        console.warn('Comunicado sin URL válido:', item);
+        return;
+      }
+
+      Linking.openURL(url).catch(err => {
+        console.error('No se pudo abrir el comunicado:', err);
+      });
+    },
+    [getAnnouncementUrl],
+  );
+
+  const latestAnnouncement = announcements[0];
+  const previousAnnouncements = useMemo(
+    () => (announcements.length > 1 ? announcements.slice(1) : []),
+    [announcements],
+  );
+
+  const header = useMemo(() => {
+    if (!latestAnnouncement) {
+      return <View style={styles.headerSpacing} />;
+    }
+
+    const image = getImageSource(latestAnnouncement);
+    const url = getAnnouncementUrl(latestAnnouncement);
+    const formattedDate = formatDate(latestAnnouncement.createdAt);
+
+    return (
+      <View style={styles.header}>
+        <Pressable
+          style={[styles.heroCard, !image && { backgroundColor: palette.surfaceAlt }]}
+          onPress={url ? () => handleOpen(latestAnnouncement) : undefined}
+          disabled={!url}
+        >
+          {image ? (
+            <View style={styles.heroImageContainer}>
+              <Image source={{ uri: image }} style={styles.heroImage} />
+              <LinearGradient
+                colors={[
+                  'rgba(0, 0, 0, 0)',
+                  'rgba(0, 0, 0, 0.25)',
+                  'rgba(0, 0, 0, 0.7)',
+                ]}
+                locations={[0, 0.55, 1]}
+                style={styles.heroGradient}
+              />
+              <View style={styles.heroOverlay}>
+                <AppText style={[styles.heroLabel, { color: palette.accentOn }]}>Último comunicado</AppText>
+                <AppText style={[styles.heroTitle, { color: palette.accentOn }]} numberOfLines={2}>
+                  {latestAnnouncement.title}
+                </AppText>
+                {latestAnnouncement.description ? (
+                  <AppText style={[styles.heroDescription, { color: palette.accentOn }]} numberOfLines={3}>
+                    {latestAnnouncement.description}
+                  </AppText>
+                ) : null}
+                {formattedDate ? (
+                  <AppText style={[styles.heroDate, { color: palette.accentOn }]}>{formattedDate}</AppText>
+                ) : null}
+              </View>
+            </View>
+          ) : (
+            <View style={styles.heroFallback}>
+              <AppText style={[styles.heroLabel, { color: palette.accent }]}>Último comunicado</AppText>
+              <AppText style={[styles.heroTitle, { color: palette.title }]}>{latestAnnouncement.title}</AppText>
+              {latestAnnouncement.description ? (
+                <AppText style={[styles.heroDescription, { color: palette.muted }]}>
+                  {latestAnnouncement.description}
+                </AppText>
+              ) : null}
+              {formattedDate ? (
+                <AppText style={[styles.heroDate, { color: palette.muted }]}>{formattedDate}</AppText>
+              ) : null}
+            </View>
+          )}
+        </Pressable>
+
+        {previousAnnouncements.length > 0 ? (
+          <AppText style={[styles.sectionTitle, { color: palette.title }]}>Comunicados anteriores</AppText>
+        ) : null}
+      </View>
+    );
+  }, [
+    latestAnnouncement,
+    getImageSource,
+    getAnnouncementUrl,
+    formatDate,
+    handleOpen,
+    palette.surfaceAlt,
+    palette.accent,
+    palette.accentOn,
+    palette.title,
+    palette.muted,
+    previousAnnouncements.length,
+  ]);
+
+  const emptyComponent = useMemo(() => {
+    if (latestAnnouncement) {
+      return null;
+    }
+
+    return (
+      <View style={styles.emptyState}>
+        <AppText style={[styles.emptyTitle, { color: palette.title }]}>Sin comunicados</AppText>
+        <AppText style={[styles.emptyDescription, { color: palette.muted }]}>
+          Cuando publiquemos un nuevo comunicado, lo vas a ver automáticamente en esta pantalla.
+        </AppText>
+      </View>
+    );
+  }, [latestAnnouncement, palette.muted, palette.title]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: Announcement }) => (
+      <AnnouncementListItem
+        item={item}
+        palette={palette}
+        onPress={handleOpen}
+        getImageSource={getImageSource}
+        formatDate={formatDate}
+        getAnnouncementUrl={getAnnouncementUrl}
+      />
+    ),
+    [formatDate, getAnnouncementUrl, getImageSource, handleOpen, palette],
+  );
+
+  if (loading) {
+    return (
+      <SafeAreaView style={[styles.loading, { backgroundColor: 'transparent' }]}>
+        <ActivityIndicator size="large" color={t.colors.primary} />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: 'transparent' }]}>
+      <FlatList
+        data={previousAnnouncements}
+        renderItem={renderItem}
+        keyExtractor={item => item.id}
+        ListHeaderComponent={header}
+        ListEmptyComponent={emptyComponent}
+        contentContainerStyle={styles.listContent}
+        showsVerticalScrollIndicator={false}
+      />
+    </SafeAreaView>
+  );
+};
+
+export default AnnouncementsScreen;
+
+type AnnouncementPalette = {
+  surface: string;
+  surfaceAlt: string;
+  title: string;
+  muted: string;
+  accent: string;
+  accentOn: string;
+};
+
+const AnnouncementListItem = memo(function AnnouncementListItem({
+  item,
+  palette,
+  onPress,
+  getImageSource,
+  formatDate,
+  getAnnouncementUrl,
+}: {
+  item: Announcement;
+  palette: AnnouncementPalette;
+  onPress: (item: Announcement) => void;
+  getImageSource: (item: Announcement) => string | undefined;
+  formatDate: (value: Announcement['createdAt']) => string;
+  getAnnouncementUrl: (item: Announcement) => string | null;
+}) {
+  const image = getImageSource(item);
+  const dateLabel = formatDate(item.createdAt);
+  const url = getAnnouncementUrl(item);
+
+  const handlePress = useCallback(() => onPress(item), [item, onPress]);
+
+  return (
+    <Pressable
+      style={[styles.card, { backgroundColor: palette.surface }]}
+      onPress={url ? handlePress : undefined}
+      disabled={!url}
+    >
+      {image ? <Image source={{ uri: image }} style={styles.cardImage} /> : null}
+      <View style={styles.cardContent}>
+        <AppText style={[styles.cardTitle, { color: palette.title }]} numberOfLines={2}>
+          {item.title}
+        </AppText>
+        {item.description ? (
+          <AppText style={[styles.cardDescription, { color: palette.muted }]} numberOfLines={3}>
+            {item.description}
+          </AppText>
+        ) : null}
+        {dateLabel ? (
+          <AppText style={[styles.cardDate, { color: palette.muted }]}>{dateLabel}</AppText>
+        ) : null}
+        {url ? <AppText style={[styles.cardLink, { color: palette.accent }]}>Ver comunicado</AppText> : null}
+      </View>
+    </Pressable>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  loading: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  listContent: {
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.lg,
+  },
+  header: {
+    marginTop: spacing.lg,
+    marginBottom: spacing.lg,
+  },
+  headerSpacing: {
+    height: spacing.lg,
+  },
+  heroCard: {
+    borderRadius: 16,
+    overflow: 'hidden',
+    marginBottom: spacing.lg,
+  },
+  heroImageContainer: {
+    height: 260,
+  },
+  heroImage: {
+    ...StyleSheet.absoluteFillObject,
+    width: '100%',
+    height: '100%',
+  },
+  heroGradient: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  heroOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'flex-end',
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.lg,
+  },
+  heroFallback: {
+    padding: spacing.lg,
+  },
+  heroLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    marginBottom: spacing.xs,
+  },
+  heroTitle: {
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: spacing.sm,
+  },
+  heroDescription: {
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: spacing.sm,
+  },
+  heroDate: {
+    fontSize: 12,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  emptyState: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing.xl,
+    paddingHorizontal: spacing.lg,
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: spacing.sm,
+    textAlign: 'center',
+  },
+  emptyDescription: {
+    fontSize: 14,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  card: {
+    borderRadius: 12,
+    overflow: 'hidden',
+    marginBottom: spacing.md,
+  },
+  cardImage: {
+    width: '100%',
+    height: 180,
+  },
+  cardContent: {
+    padding: spacing.md,
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: spacing.xs,
+  },
+  cardDescription: {
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: spacing.xs,
+  },
+  cardDate: {
+    fontSize: 12,
+  },
+  cardLink: {
+    marginTop: spacing.sm,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/src/types/RootStackParamList.ts
+++ b/src/types/RootStackParamList.ts
@@ -10,6 +10,19 @@ export interface NewsItem {
   createdAt: any;
 }
 
+export interface Announcement {
+  id: string;
+  title: string;
+  description?: string;
+  imageUrl?: string;
+  img?: string;
+  image?: string;
+  link?: string;
+  url?: string;
+  fileUrl?: string;
+  createdAt: any;
+}
+
 export type RootStackParamList = {
   Main: undefined;
   BenefitDetail: { url: string };


### PR DESCRIPTION
## Summary
- add a Firestore-backed announcements screen that highlights the latest comunicado and lists previous ones
- register the announcements tab in the bottom navigation with a megaphone icon
- define a reusable `Announcement` type for Firestore records

## Testing
- not run (static analysis only)


------
https://chatgpt.com/codex/tasks/task_e_68dd5988d32c8324812a8df768af6c9a